### PR TITLE
Resolve chronometer display glitch on dashboard redirect

### DIFF
--- a/src/app/components/prebuild-workout/prebuild-workout.component.ts
+++ b/src/app/components/prebuild-workout/prebuild-workout.component.ts
@@ -355,7 +355,7 @@ export class PrebuildWorkoutComponent implements OnInit {
 		);
 	}
 
-	public saveWorkout(trainingTime?: number) {
+	public async saveWorkout(trainingTime?: number) {
 		this.workout.date = this.fromStringToTimestamp(this.date);
 		if (!this.editMode && !trainingTime)
 			this.workout.trainingTime = this.userService.getTrainingTime();
@@ -365,7 +365,7 @@ export class PrebuildWorkoutComponent implements OnInit {
 		this.userService.endChronometer();
 		this.userService.endRest();
 		this.userService.updateWorkout(this.workout);
-		this.userService.saveWorkout();
+		await this.userService.saveWorkout();
 
 		localStorage.removeItem("workoutProgress");
 		localStorage.removeItem("workoutCompleteTime");


### PR DESCRIPTION
Fixes a brief chronometer display issue occurring after redirecting to the dashboard when saving a workout. The problem was caused by a missing 'await' when interacting with the user-service. I've added the necessary 'await' to ensure proper synchronization, eliminating the glitch.